### PR TITLE
Add SwiftUI iOS app skeleton

### DIFF
--- a/iAPSAdvisor/App/iAPSAdvisorApp.swift
+++ b/iAPSAdvisor/App/iAPSAdvisorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct iAPSAdvisorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/iAPSAdvisor/Info.plist
+++ b/iAPSAdvisor/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.iapsadvisor</string>
+    <key>CFBundleName</key>
+    <string>iAPSAdvisor</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+</dict>
+</plist>

--- a/iAPSAdvisor/Package.swift
+++ b/iAPSAdvisor/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "iAPSAdvisor",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(name: "iAPSAdvisor", targets: ["iAPSAdvisor"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "iAPSAdvisor",
+            path: ".",
+            sources: ["App", "Views"]
+        )
+    ]
+)

--- a/iAPSAdvisor/README.md
+++ b/iAPSAdvisor/README.md
@@ -1,0 +1,18 @@
+# iAPSAdvisor
+
+A SwiftUI-based iOS app targeting iOS 15+.
+
+## Development
+
+1. Open the project in Xcode.
+2. Build and run on an iOS 15+ simulator or device.
+
+## Features
+
+- Displays a welcome message
+- Lets you enter a Team ID
+- Prints the derived App Group name `group.com.{TEAMID}.loopkit.LoopGroup` to the console
+
+## Note
+
+This project currently contains placeholder UI and no external dependencies.

--- a/iAPSAdvisor/Views/ContentView.swift
+++ b/iAPSAdvisor/Views/ContentView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var teamID: String = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Welcome to iAPSAdvisor")
+                .font(.headline)
+            TextField("TEAMID", text: $teamID)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            Button("Print App Group") {
+                let appGroup = "group.com.\(teamID).loopkit.LoopGroup"
+                print(appGroup)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}


### PR DESCRIPTION
## Summary
- scaffold iAPSAdvisor SwiftUI app with entry point, views, and plist
- add Swift Package manifest targeting iOS 15+

## Testing
- `swift build` *(fails: no such module 'SwiftUI' — SwiftUI SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_689391de132c8326abaa424306e2030d