### PR TITLE
Add Nightscout data fetching service and UI buttons

### DIFF
--- a/iAPSAdvisor/App/NightscoutService.swift
+++ b/iAPSAdvisor/App/NightscoutService.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+struct BGReading: Codable {
+    let sgv: Int
+    let dateString: String
+}
+
+struct InsulinTreatment: Codable {
+    let eventType: String
+    let created_at: String?
+    let insulin: Double?
+}
+
+struct CarbTreatment: Codable {
+    let eventType: String
+    let created_at: String?
+    let carbs: Double?
+}
+
+class NightscoutService {
+    private let baseURL: URL
+    private let apiToken: String?
+
+    init(baseURL: URL, apiToken: String? = nil) {
+        self.baseURL = baseURL
+        self.apiToken = apiToken
+    }
+
+    private func makeRequest(path: String, queryItems: [URLQueryItem]) -> URLRequest? {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false) else { return nil }
+        components.queryItems = queryItems
+        guard let url = components.url else { return nil }
+        var request = URLRequest(url: url)
+        if let token = apiToken {
+            request.addValue(token, forHTTPHeaderField: "api-secret")
+        }
+        return request
+    }
+
+    func fetchBGReadings(startDate: String) async throws -> [BGReading] {
+        let items = [
+            URLQueryItem(name: "count", value: "100"),
+            URLQueryItem(name: "find[dateString][$gte]", value: startDate)
+        ]
+        guard let request = makeRequest(path: "api/v1/entries.json", queryItems: items) else { return [] }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode([BGReading].self, from: data)
+    }
+
+    func fetchInsulinTreatments(startDate: String? = nil) async throws -> [InsulinTreatment] {
+        var items = [URLQueryItem(name: "find[eventType]", value: "Insulin Injection")]
+        if let start = startDate {
+            items.append(URLQueryItem(name: "find[created_at][$gte]", value: start))
+        }
+        guard let request = makeRequest(path: "api/v1/treatments.json", queryItems: items) else { return [] }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode([InsulinTreatment].self, from: data)
+    }
+
+    func fetchCarbIntake() async throws -> [CarbTreatment] {
+        let items = [URLQueryItem(name: "find[eventType]", value: "Carb Correction")]
+        guard let request = makeRequest(path: "api/v1/treatments.json", queryItems: items) else { return [] }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode([CarbTreatment].self, from: data)
+    }
+}
+

--- a/iAPSAdvisor/Views/ContentView.swift
+++ b/iAPSAdvisor/Views/ContentView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var teamID: String = ""
+    @State private var nightscoutURL: String = ""
+    @State private var apiToken: String = ""
 
     var body: some View {
         VStack(spacing: 20) {
@@ -10,9 +12,66 @@ struct ContentView: View {
             TextField("TEAMID", text: $teamID)
                 .textFieldStyle(.roundedBorder)
                 .padding(.horizontal)
+            TextField("Nightscout URL", text: $nightscoutURL)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            TextField("API Token (optional)", text: $apiToken)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
             Button("Print App Group") {
                 let appGroup = "group.com.\(teamID).loopkit.LoopGroup"
                 print(appGroup)
+            }
+            Button("Fetch BG Readings") {
+                guard let url = URL(string: nightscoutURL) else {
+                    print("Invalid URL")
+                    return
+                }
+                let service = NightscoutService(baseURL: url, apiToken: apiToken.isEmpty ? nil : apiToken)
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                let startDate = formatter.string(from: Date())
+                Task {
+                    do {
+                        let readings = try await service.fetchBGReadings(startDate: startDate)
+                        print(readings)
+                    } catch {
+                        print("Error fetching BG readings: \(error)")
+                    }
+                }
+            }
+            Button("Fetch Insulin Events") {
+                guard let url = URL(string: nightscoutURL) else {
+                    print("Invalid URL")
+                    return
+                }
+                let service = NightscoutService(baseURL: url, apiToken: apiToken.isEmpty ? nil : apiToken)
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                let startDate = formatter.string(from: Date())
+                Task {
+                    do {
+                        let events = try await service.fetchInsulinTreatments(startDate: startDate)
+                        print(events)
+                    } catch {
+                        print("Error fetching insulin events: \(error)")
+                    }
+                }
+            }
+            Button("Fetch Carb Events") {
+                guard let url = URL(string: nightscoutURL) else {
+                    print("Invalid URL")
+                    return
+                }
+                let service = NightscoutService(baseURL: url, apiToken: apiToken.isEmpty ? nil : apiToken)
+                Task {
+                    do {
+                        let events = try await service.fetchCarbIntake()
+                        print(events)
+                    } catch {
+                        print("Error fetching carb events: \(error)")
+                    }
+                }
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- add `NightscoutService` for BG readings, insulin treatments, and carb intake with optional api token header
- extend `ContentView` with fields for Nightscout URL & API token and buttons to fetch data

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6893975a9d2483268b13b2eb2f383d9c