### PR TITLE
Add GitHub Actions workflow for iOS build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,52 @@
+name: iOS Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+
+      - name: Resolve Swift package dependencies
+        working-directory: iAPSAdvisor
+        run: swift package resolve
+
+      - name: Import signing certificates
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.P12_BASE64 }}
+          p12-password: ${{ secrets.P12_PASSWORD }}
+          mobileprovision-base64: ${{ secrets.PROVISIONING_PROFILE }}
+
+      - name: Build archive
+        working-directory: iAPSAdvisor
+        run: |
+          xcodebuild \
+            -scheme iAPSAdvisor \
+            -configuration Release \
+            -archivePath $PWD/build/iAPSAdvisor.xcarchive \
+            archive
+
+      - name: Export IPA
+        working-directory: iAPSAdvisor
+        run: |
+          xcodebuild \
+            -exportArchive \
+            -archivePath $PWD/build/iAPSAdvisor.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath $PWD/build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: iAPSAdvisor-ipa
+          path: iAPSAdvisor/build/*.ipa


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build, sign, and export the iOS app

## Testing
- `swift test --package-path iAPSAdvisor` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68c6e49742f4832696cb8a0dd3b3ebab