### PR TITLE
Disable arbitrary network loads

### DIFF
--- a/iAPSAdvisor/Info.plist
+++ b/iAPSAdvisor/Info.plist
@@ -17,7 +17,7 @@
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsArbitraryLoads</key>
-        <true/>
+        <false/>
     </dict>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>


### PR DESCRIPTION
## Summary
- restrict app transport security by disabling NSAllowsArbitraryLoads

## Testing
- `cd iAPSAdvisor && swift test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68c6f93d4b488326b93b1cc3492f1fd8