### PR TITLE
Add Xcode project for iAPSAdvisor and align CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,15 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+      - name: Build and test
         run: |
           cd iAPSAdvisor
-          swift build
-      - name: Test
-        run: |
-          cd iAPSAdvisor
-          swift test
+          xcodebuild \
+            -project iAPSAdvisor.xcodeproj \
+            -scheme iAPSAdvisor \
+            -destination 'platform=iOS Simulator,name=iPhone 14' \
+            test

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,6 +31,7 @@ jobs:
         working-directory: iAPSAdvisor
         run: |
           xcodebuild \
+            -project iAPSAdvisor.xcodeproj \
             -scheme iAPSAdvisor \
             -configuration Release \
             -archivePath $PWD/build/iAPSAdvisor.xcarchive \

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -31,6 +31,7 @@ jobs:
         working-directory: iAPSAdvisor
         run: |
           xcodebuild \
+            -project iAPSAdvisor.xcodeproj \
             -scheme iAPSAdvisor \
             -destination 'platform=iOS Simulator,name=iPhone 14' \
             test
@@ -39,6 +40,7 @@ jobs:
         working-directory: iAPSAdvisor
         run: |
           xcodebuild \
+            -project iAPSAdvisor.xcodeproj \
             -scheme iAPSAdvisor \
             -configuration Release \
             -archivePath $PWD/build/iAPSAdvisor.xcarchive \

--- a/iAPSAdvisor/iAPSAdvisor.xcodeproj/project.pbxproj
+++ b/iAPSAdvisor/iAPSAdvisor.xcodeproj/project.pbxproj
@@ -1,0 +1,462 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+1A2B3C4D1E2F3A4B5C6D7EB3 /* iAPSAdvisorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D1E2F3A4B5C6D7EAA /* iAPSAdvisorApp.swift */; };
+1A2B3C4D1E2F3A4B5C6D7EB4 /* NightscoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D1E2F3A4B5C6D7EAB /* NightscoutService.swift */; };
+1A2B3C4D1E2F3A4B5C6D7EB5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D1E2F3A4B5C6D7EAC /* ContentView.swift */; };
+1A2B3C4D1E2F3A4B5C6D7EB6 /* NightscoutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D1E2F3A4B5C6D7EAE /* NightscoutServiceTests.swift */; };
+1A2B3C4D1E2F3A4B5C6D7EC1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D1E2F3A4B5C6D7EC0 /* XCTest.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+1A2B3C4D1E2F3A4B5C6D7EBA /* PBXContainerItemProxy */ = {
+isa = PBXContainerItemProxy;
+containerPortal = 1A2B3C4D1E2F3A4B5C6D7E91 /* Project object */;
+proxyType = 1;
+remoteGlobalIDString = 1A2B3C4D1E2F3A4B5C6D7E92;
+remoteInfo = iAPSAdvisor;
+};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+1A2B3C4D1E2F3A4B5C6D7EAA /* iAPSAdvisorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iAPSAdvisorApp.swift; sourceTree = "<group>"; };
+1A2B3C4D1E2F3A4B5C6D7EAB /* NightscoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutService.swift; sourceTree = "<group>"; };
+1A2B3C4D1E2F3A4B5C6D7EAC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+1A2B3C4D1E2F3A4B5C6D7EAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+1A2B3C4D1E2F3A4B5C6D7EAE /* NightscoutServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutServiceTests.swift; sourceTree = "<group>"; };
+1A2B3C4D1E2F3A4B5C6D7EB7 /* iAPSAdvisor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iAPSAdvisor.app; sourceTree = BUILT_PRODUCTS_DIR; };
+1A2B3C4D1E2F3A4B5C6D7EB8 /* iAPSAdvisorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iAPSAdvisorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+1A2B3C4D1E2F3A4B5C6D7EC0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+1A2B3C4D1E2F3A4B5C6D7EA4 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+1A2B3C4D1E2F3A4B5C6D7EA7 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+1A2B3C4D1E2F3A4B5C6D7EC1 /* XCTest.framework in Frameworks */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+1A2B3C4D1E2F3A4B5C6D7E90 = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EAF /* App */,
+1A2B3C4D1E2F3A4B5C6D7EB0 /* Views */,
+1A2B3C4D1E2F3A4B5C6D7EB1 /* Tests */,
+1A2B3C4D1E2F3A4B5C6D7EAD /* Info.plist */,
+1A2B3C4D1E2F3A4B5C6D7EBF /* Products */,
+1A2B3C4D1E2F3A4B5C6D7EC2 /* Frameworks */
+);
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EAF /* App */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EAA /* iAPSAdvisorApp.swift */,
+1A2B3C4D1E2F3A4B5C6D7EAB /* NightscoutService.swift */
+);
+path = App;
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EB0 /* Views */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EAC /* ContentView.swift */
+);
+path = Views;
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EB1 /* Tests */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EB2 /* iAPSAdvisorTests */
+);
+path = Tests;
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EB2 /* iAPSAdvisorTests */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EAE /* NightscoutServiceTests.swift */
+);
+path = iAPSAdvisorTests;
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EBF /* Products */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EB7 /* iAPSAdvisor.app */,
+1A2B3C4D1E2F3A4B5C6D7EB8 /* iAPSAdvisorTests.xctest */
+);
+name = Products;
+sourceTree = "<group>";
+};
+1A2B3C4D1E2F3A4B5C6D7EC2 /* Frameworks */ = {
+isa = PBXGroup;
+children = (
+1A2B3C4D1E2F3A4B5C6D7EC0 /* XCTest.framework */
+);
+name = Frameworks;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+1A2B3C4D1E2F3A4B5C6D7E92 /* iAPSAdvisor */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 1A2B3C4D1E2F3A4B5C6D7E94 /* Build configuration list for PBXNativeTarget "iAPSAdvisor" */;
+buildPhases = (
+1A2B3C4D1E2F3A4B5C6D7EA3 /* Sources */,
+1A2B3C4D1E2F3A4B5C6D7EA4 /* Frameworks */,
+1A2B3C4D1E2F3A4B5C6D7EA5 /* Resources */
+);
+buildRules = (
+);
+dependencies = (
+);
+name = iAPSAdvisor;
+productName = iAPSAdvisor;
+productReference = 1A2B3C4D1E2F3A4B5C6D7EB7 /* iAPSAdvisor.app */;
+productType = "com.apple.product-type.application";
+};
+1A2B3C4D1E2F3A4B5C6D7E93 /* iAPSAdvisorTests */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 1A2B3C4D1E2F3A4B5C6D7E97 /* Build configuration list for PBXNativeTarget "iAPSAdvisorTests" */;
+buildPhases = (
+1A2B3C4D1E2F3A4B5C6D7EA6 /* Sources */,
+1A2B3C4D1E2F3A4B5C6D7EA7 /* Frameworks */,
+1A2B3C4D1E2F3A4B5C6D7EA8 /* Resources */
+);
+buildRules = (
+);
+dependencies = (
+1A2B3C4D1E2F3A4B5C6D7EBB /* PBXTargetDependency */
+);
+name = iAPSAdvisorTests;
+productName = iAPSAdvisorTests;
+productReference = 1A2B3C4D1E2F3A4B5C6D7EB8 /* iAPSAdvisorTests.xctest */;
+productType = "com.apple.product-type.bundle.unit-test";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+1A2B3C4D1E2F3A4B5C6D7E91 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = YES;
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+ORGANIZATIONNAME = "OpenAPS";
+TargetAttributes = {
+1A2B3C4D1E2F3A4B5C6D7E92 = {
+CreatedOnToolsVersion = 15.0;
+};
+1A2B3C4D1E2F3A4B5C6D7E93 = {
+CreatedOnToolsVersion = 15.0;
+};
+};
+};
+buildConfigurationList = 1A2B3C4D1E2F3A4B5C6D7EA0 /* Build configuration list for PBXProject "iAPSAdvisor" */;
+compatibilityVersion = "Xcode 15.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+);
+mainGroup = 1A2B3C4D1E2F3A4B5C6D7E90;
+productRefGroup = 1A2B3C4D1E2F3A4B5C6D7EBF /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+1A2B3C4D1E2F3A4B5C6D7E92 /* iAPSAdvisor */,
+1A2B3C4D1E2F3A4B5C6D7E93 /* iAPSAdvisorTests */
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+1A2B3C4D1E2F3A4B5C6D7EA5 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+1A2B3C4D1E2F3A4B5C6D7EA8 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+1A2B3C4D1E2F3A4B5C6D7EA3 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+1A2B3C4D1E2F3A4B5C6D7EB3 /* iAPSAdvisorApp.swift in Sources */,
+1A2B3C4D1E2F3A4B5C6D7EB4 /* NightscoutService.swift in Sources */,
+1A2B3C4D1E2F3A4B5C6D7EB5 /* ContentView.swift in Sources */
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+1A2B3C4D1E2F3A4B5C6D7EA6 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+1A2B3C4D1E2F3A4B5C6D7EB6 /* NightscoutServiceTests.swift in Sources */
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+1A2B3C4D1E2F3A4B5C6D7EBB /* PBXTargetDependency */ = {
+isa = PBXTargetDependency;
+target = 1A2B3C4D1E2F3A4B5C6D7E92 /* iAPSAdvisor */;
+targetProxy = 1A2B3C4D1E2F3A4B5C6D7EBA /* PBXContainerItemProxy */;
+};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+1A2B3C4D1E2F3A4B5C6D7E95 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+MARKETING_VERSION = 1.0.0;
+PRODUCT_BUNDLE_IDENTIFIER = org.openaps.iAPSAdvisor;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.9;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+1A2B3C4D1E2F3A4B5C6D7E96 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+MARKETING_VERSION = 1.0.0;
+PRODUCT_BUNDLE_IDENTIFIER = org.openaps.iAPSAdvisor;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.9;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+1A2B3C4D1E2F3A4B5C6D7E98 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+PRODUCT_BUNDLE_IDENTIFIER = org.openaps.iAPSAdvisorTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.9;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+1A2B3C4D1E2F3A4B5C6D7E99 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+PRODUCT_BUNDLE_IDENTIFIER = org.openaps.iAPSAdvisorTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.9;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+1A2B3C4D1E2F3A4B5C6D7EA1 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_IDENTITY = "iPhone Developer";
+COPY_PHASE_STRIP = NO;
+DEVELOPMENT_TEAM = "";
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+MTL_FAST_MATH = YES;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+};
+name = Debug;
+};
+1A2B3C4D1E2F3A4B5C6D7EA2 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_IDENTITY = "iPhone Developer";
+COPY_PHASE_STRIP = NO;
+DEVELOPMENT_TEAM = "";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+MTL_FAST_MATH = YES;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+1A2B3C4D1E2F3A4B5C6D7E94 /* Build configuration list for PBXNativeTarget "iAPSAdvisor" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1A2B3C4D1E2F3A4B5C6D7E95 /* Debug */,
+1A2B3C4D1E2F3A4B5C6D7E96 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+1A2B3C4D1E2F3A4B5C6D7E97 /* Build configuration list for PBXNativeTarget "iAPSAdvisorTests" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1A2B3C4D1E2F3A4B5C6D7E98 /* Debug */,
+1A2B3C4D1E2F3A4B5C6D7E99 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+1A2B3C4D1E2F3A4B5C6D7EA0 /* Build configuration list for PBXProject "iAPSAdvisor" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1A2B3C4D1E2F3A4B5C6D7EA1 /* Debug */,
+1A2B3C4D1E2F3A4B5C6D7EA2 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+
+};
+rootObject = 1A2B3C4D1E2F3A4B5C6D7E91 /* Project object */;
+}

--- a/iAPSAdvisor/iAPSAdvisor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iAPSAdvisor/iAPSAdvisor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iAPSAdvisor/iAPSAdvisor.xcodeproj/xcshareddata/xcschemes/iAPSAdvisor.xcscheme
+++ b/iAPSAdvisor/iAPSAdvisor.xcodeproj/xcshareddata/xcschemes/iAPSAdvisor.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A2B3C4D1E2F3A4B5C6D7E92"
+               BuildableName = "iAPSAdvisor.app"
+               BlueprintName = "iAPSAdvisor"
+               ReferencedContainer = "container:iAPSAdvisor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A2B3C4D1E2F3A4B5C6D7E93"
+               BuildableName = "iAPSAdvisorTests.xctest"
+               BlueprintName = "iAPSAdvisorTests"
+               ReferencedContainer = "container:iAPSAdvisor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A2B3C4D1E2F3A4B5C6D7E92"
+            BuildableName = "iAPSAdvisor.app"
+            BlueprintName = "iAPSAdvisor"
+            ReferencedContainer = "container:iAPSAdvisor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A2B3C4D1E2F3A4B5C6D7E92"
+            BuildableName = "iAPSAdvisor.app"
+            BlueprintName = "iAPSAdvisor"
+            ReferencedContainer = "container:iAPSAdvisor.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A2B3C4D1E2F3A4B5C6D7E92"
+            BuildableName = "iAPSAdvisor.app"
+            BlueprintName = "iAPSAdvisor"
+            ReferencedContainer = "container:iAPSAdvisor.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- add a committed iAPSAdvisor.xcodeproj that defines the app and unit test targets with the shared scheme
- configure the project to use the existing bundle identifier and target iOS 15+
- update CI and release workflows to build and test the new Xcode project explicitly

## Testing
- not run (Xcode is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68de95c5b408832680bcdfb3cdbedc3e